### PR TITLE
Add competition mode filters and participant flags

### DIFF
--- a/prisma/migrations/20250630000000_participant_flags/migration.sql
+++ b/prisma/migrations/20250630000000_participant_flags/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Participant" 
+  ADD COLUMN "isIndividual" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "isTeam" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "isCity" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,9 @@ model Participant {
   institution String
   birthYear   Int?
   gender      String
+  isIndividual Boolean @default(true)
+  isTeam       Boolean @default(true)
+  isCity       Boolean @default(false)
   results     Result[]
 }
 

--- a/src/app/api/competitions/route.js
+++ b/src/app/api/competitions/route.js
@@ -6,6 +6,7 @@ export async function GET(req) {
   /* 0) ключ дисциплины из query */
   const key = req.nextUrl.searchParams.get("key");
   if (!key) return new Response("key required", { status: 400 });
+  const mode = req.nextUrl.searchParams.get("mode") ?? "individual";
 
   /* 1) сама дисциплина + все результаты */
   const discipline = await prisma.discipline.findUnique({
@@ -16,9 +17,12 @@ export async function GET(req) {
 
   /* 2) базовый список участников c учётом пола дисциплины */
   let participants = await prisma.participant.findMany({
-    where: discipline.gender
-      ? { gender: discipline.gender === "girls" ? "Ж" : "М" }
-      : {},
+    where: {
+      ...(discipline.gender
+        ? { gender: discipline.gender === "girls" ? "Ж" : "М" }
+        : {}),
+      ...(mode === "individual" ? { isIndividual: true } : { isTeam: true }),
+    },
     orderBy: { id: "asc" },
   });
 

--- a/src/app/api/final/route.js
+++ b/src/app/api/final/route.js
@@ -36,7 +36,7 @@ export async function GET(req) {
       FROM    "Participant" p
       LEFT JOIN "Result"     r ON r."participantId" = p.id
       LEFT JOIN "Discipline" d ON d.id             = r."disciplineId"
-      WHERE   p.gender = ${gLetter}
+      WHERE   p.gender = ${gLetter} AND p."isIndividual" = true
       GROUP BY p.id
     `;
 
@@ -47,16 +47,17 @@ export async function GET(req) {
 
   const members = await prisma.$queryRaw`
     SELECT  p.id, p."lastName", p."firstName",
-            p.abbrev, p.institution, p.gender,
+            p.abbrev, p.institution, p.gender, p."isCity",
             COALESCE(SUM(r.points),0) AS total_points
     FROM    "Participant" p
     LEFT JOIN "Result" r ON r."participantId" = p.id
+    WHERE   p."isTeam" = true
     GROUP BY p.id
   `;
 
   const filt = members.filter(m=>{
-    if (scope==="region") return !m.institution.startsWith('г.');
-    if (scope==="city")   return  m.institution.startsWith('г.');
+    if (scope==="region") return !m.isCity;
+    if (scope==="city")   return  m.isCity;
     return true;          // all
   });
 

--- a/src/app/api/participants/route.js
+++ b/src/app/api/participants/route.js
@@ -18,6 +18,9 @@ export async function POST(req) {
       institution: p.institution,
       birthYear:   p.birthYear ? Number(p.birthYear) : null,
       gender:      p.gender,
+      isIndividual: p.isIndividual ?? true,
+      isTeam:       p.isTeam       ?? true,
+      isCity:       p.isCity       ?? false,
     },
   });
   return Response.json(created, { status: 201 });

--- a/src/app/api/teams/route.js
+++ b/src/app/api/teams/route.js
@@ -16,15 +16,17 @@ export async function GET(req) {
   const members = await prisma.$queryRaw`
     SELECT  p.id,
             p.institution,
+            p."isCity",
             COALESCE(SUM(r.points),0) AS total_points
     FROM    "Participant" p
     LEFT JOIN "Result" r ON r."participantId" = p.id
+    WHERE   p."isTeam" = true
     GROUP BY p.id
   `;
 
   const filt = members.filter((m) => {
-    if (scope === "region") return !m.institution.startsWith('г.');
-    if (scope === "city") return m.institution.startsWith('г.');
+    if (scope === "region") return !m.isCity;
+    if (scope === "city") return m.isCity;
     return true;
   });
 

--- a/src/app/competitions/page.js
+++ b/src/app/competitions/page.js
@@ -11,19 +11,20 @@ const tabs = [
 
 export default function CompetitionsPage() {
   const [active, setActive]  = useState(tabs[0].key);
+  const [mode,   setMode]    = useState("individual");
   const [columns, setCols]   = useState([]);
   const [rows,    setRows]   = useState([]);
   const [editId,  setEditId] = useState(null);      // id строки, редактируемой сейчас
   const [draft,   setDraft]  = useState({ value:"", points:"" });
 
   /* загрузка */
-  const load = async (key) => {
-    const json = await fetch(`/api/competitions?key=${key}`).then(r=>r.json());
+  const load = async (key, md) => {
+    const json = await fetch(`/api/competitions?key=${key}&mode=${md}`).then(r=>r.json());
     setCols(json.columns);
     setRows(json.rows);
     setEditId(null);
   };
-  useEffect(()=>{ load(active); }, [active]);
+  useEffect(()=>{ load(active, mode); }, [active, mode]);
 
   /* сохранить */
   const saveRow = async (row) => {
@@ -37,12 +38,26 @@ export default function CompetitionsPage() {
         points: draft.points || null,
       }),
     });
-    load(active);
+    load(active, mode);
   };
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Соревнования</h1>
+
+      {/* режим участия */}
+      <div className="flex gap-4 mb-4">
+        {[{key:"individual",label:"Индивидуальный"},
+          {key:"team",label:"Командный"}].map(t=>(
+          <button key={t.key} onClick={()=>setMode(t.key)}
+            className={(mode===t.key
+                      ?"border-blue-600 text-blue-600"
+                      :"border-transparent text-gray-600 hover:text-gray-800")
+                    +" px-4 py-1 border-b-2 font-medium"}>
+            {t.label}
+          </button>
+        ))}
+      </div>
 
       {/* вкладки */}
       <div className="flex border-b mb-4">

--- a/src/components/participantsForm.js
+++ b/src/components/participantsForm.js
@@ -14,11 +14,14 @@ export default function ParticipantsForm({ onAdded }) {
     institution: "",
     birthYear:   "",
     gender:      "Ж",
+    isIndividual: true,
+    isTeam:       true,
+    isCity:       false,
   });
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm((f) => ({ ...f, [name]: value }));
+    const { name, type, checked, value } = e.target;
+    setForm((f) => ({ ...f, [name]: type === "checkbox" ? checked : value }));
   };
 
   const handleSubmit = async (e) => {
@@ -34,6 +37,7 @@ export default function ParticipantsForm({ onAdded }) {
     setForm({
       lastName: "", firstName: "", abbrev: "",
       institution: "", birthYear: "", gender: "Ж",
+      isIndividual: true, isTeam: true, isCity: false,
     });
     onAdded();
   };
@@ -96,6 +100,34 @@ export default function ParticipantsForm({ onAdded }) {
         <option>Ж</option>
         <option>М</option>
       </select>
+
+      {/* Участие */}
+      <div className="col-span-full flex gap-4">
+        <label className="flex items-center gap-1">
+          <input type="checkbox" name="isIndividual"
+                 checked={form.isIndividual} onChange={handleChange} />
+          Индивид.
+        </label>
+        <label className="flex items-center gap-1">
+          <input type="checkbox" name="isTeam"
+                 checked={form.isTeam} onChange={handleChange} />
+          Командн.
+        </label>
+      </div>
+
+      {/* Область / Город */}
+      <div className="col-span-full flex gap-4">
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={!form.isCity}
+                 onChange={()=>setForm(f=>({...f,isCity:false}))} />
+          Область
+        </label>
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={form.isCity}
+                 onChange={()=>setForm(f=>({...f,isCity:true}))} />
+          Город
+        </label>
+      </div>
 
       {/* Кнопка */}
       <button

--- a/src/components/participantsTable.js
+++ b/src/components/participantsTable.js
@@ -45,7 +45,7 @@ export default function ParticipantsTable({ reloadFlag, onReload }) {
         <table className="min-w-full text-sm text-gray-700 border-collapse rounded-md overflow-hidden shadow-sm">
           <thead className="bg-gray-50 text-xs text-gray-500 uppercase">
             <tr>
-              {["№","Фамилия","Имя","СУЗ","Год","Пол",""].map(h=>(
+              {["№","Фамилия","Имя","СУЗ","Год","Пол","Инд","Ком","Город",""].map(h=>(
                 <th key={h}
                     className="px-3 py-2 font-medium border border-gray-200 bg-gray-100 whitespace-nowrap">
                   {h}
@@ -62,6 +62,9 @@ export default function ParticipantsTable({ reloadFlag, onReload }) {
                 <td className="px-3 py-2 border border-gray-100 whitespace-nowrap">{p.abbrev}</td>
                 <td className="px-3 py-2 border border-gray-100 whitespace-nowrap">{p.birthYear}</td>
                 <td className="px-3 py-2 border border-gray-100 whitespace-nowrap">{p.gender}</td>
+                <td className="px-3 py-2 border border-gray-100 whitespace-nowrap text-center">{p.isIndividual ? '✓' : ''}</td>
+                <td className="px-3 py-2 border border-gray-100 whitespace-nowrap text-center">{p.isTeam ? '✓' : ''}</td>
+                <td className="px-3 py-2 border border-gray-100 whitespace-nowrap text-center">{p.isCity ? 'г' : 'обл'}</td>
                 <td className="px-3 py-2 border border-gray-100 whitespace-nowrap space-x-2">
                   <button onClick={()=>openEdit(p)}  className="text-blue-600">✏️</button>
                   <button onClick={()=>remove(p.id)} className="text-red-600">🗑️</button>
@@ -70,7 +73,7 @@ export default function ParticipantsTable({ reloadFlag, onReload }) {
             ))}
             {data.length===0 && (
               <tr>
-                <td colSpan={8} className="px-6 py-6 text-center text-gray-500">
+                <td colSpan={10} className="px-6 py-6 text-center text-gray-500">
                   Нет данных
                 </td>
               </tr>
@@ -96,6 +99,32 @@ export default function ParticipantsTable({ reloadFlag, onReload }) {
                 className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none"
               />
             ))}
+
+            {/* чекбоксы */}
+            <label className="inline-flex items-center gap-2">
+              <input type="checkbox" name="isIndividual"
+                     checked={editForm.isIndividual || false}
+                     onChange={e=>setEditForm(f=>({...f,isIndividual:e.target.checked}))}/>
+              Индивид.
+            </label>
+            <label className="inline-flex items-center gap-2 ml-4">
+              <input type="checkbox" name="isTeam"
+                     checked={editForm.isTeam || false}
+                     onChange={e=>setEditForm(f=>({...f,isTeam:e.target.checked}))}/>
+              Командн.
+            </label>
+            <div className="flex gap-4 mt-2">
+              <label className="inline-flex items-center gap-1">
+                <input type="checkbox" checked={!editForm.isCity}
+                       onChange={()=>setEditForm(f=>({...f,isCity:false}))}/>
+                Область
+              </label>
+              <label className="inline-flex items-center gap-1">
+                <input type="checkbox" checked={editForm.isCity}
+                       onChange={()=>setEditForm(f=>({...f,isCity:true}))}/>
+                Город
+              </label>
+            </div>
 
             <div className="flex justify-end space-x-2">
               <button onClick={()=>setEditRow(null)}


### PR DESCRIPTION
## Summary
- track whether a participant competes individually or in teams and if they are from the city
- add migration for new participant fields
- show new checkboxes on participant form and table
- allow choosing Individual/Team on competitions page
- filter competitions and final results using new flags

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bc3555fc832dbb61c0dcc573420e