### PR TITLE
Add scope filters to competitions and final pages

### DIFF
--- a/src/app/api/competitions/route.js
+++ b/src/app/api/competitions/route.js
@@ -7,6 +7,7 @@ export async function GET(req) {
   const key = req.nextUrl.searchParams.get("key");
   if (!key) return new Response("key required", { status: 400 });
   const mode = req.nextUrl.searchParams.get("mode") ?? "individual";
+  const scope = req.nextUrl.searchParams.get("scope") ?? "all"; // region | city | all
 
   /* 1) сама дисциплина + все результаты */
   const discipline = await prisma.discipline.findUnique({
@@ -22,6 +23,11 @@ export async function GET(req) {
         ? { gender: discipline.gender === "girls" ? "Ж" : "М" }
         : {}),
       ...(mode === "individual" ? { isIndividual: true } : { isTeam: true }),
+      ...(scope === "region"
+        ? { isCity: false }
+        : scope === "city"
+          ? { isCity: true }
+          : {}),
     },
     orderBy: { id: "asc" },
   });

--- a/src/app/competitions/page.js
+++ b/src/app/competitions/page.js
@@ -12,19 +12,20 @@ const tabs = [
 export default function CompetitionsPage() {
   const [active, setActive]  = useState(tabs[0].key);
   const [mode,   setMode]    = useState("individual");
+  const [scope,  setScope]   = useState("all"); // region | city | all
   const [columns, setCols]   = useState([]);
   const [rows,    setRows]   = useState([]);
   const [editId,  setEditId] = useState(null);      // id строки, редактируемой сейчас
   const [draft,   setDraft]  = useState({ value:"", points:"" });
 
   /* загрузка */
-  const load = async (key, md) => {
-    const json = await fetch(`/api/competitions?key=${key}&mode=${md}`).then(r=>r.json());
+  const load = async (key, md, sc) => {
+    const json = await fetch(`/api/competitions?key=${key}&mode=${md}&scope=${sc}`).then(r=>r.json());
     setCols(json.columns);
     setRows(json.rows);
     setEditId(null);
   };
-  useEffect(()=>{ load(active, mode); }, [active, mode]);
+  useEffect(()=>{ load(active, mode, scope); }, [active, mode, scope]);
 
   /* сохранить */
   const saveRow = async (row) => {
@@ -38,7 +39,7 @@ export default function CompetitionsPage() {
         points: draft.points || null,
       }),
     });
-    load(active, mode);
+    load(active, mode, scope);
   };
 
   return (
@@ -57,6 +58,13 @@ export default function CompetitionsPage() {
             {t.label}
           </button>
         ))}
+
+        <select value={scope} onChange={e=>setScope(e.target.value)}
+                className="border px-3 py-1 rounded ml-4">
+          <option value="region">Область</option>
+          <option value="city">Город</option>
+          <option value="all">Все</option>
+        </select>
       </div>
 
       {/* вкладки */}

--- a/src/app/final/page.js
+++ b/src/app/final/page.js
@@ -158,7 +158,7 @@ export default function FinalPage() {
           <option value="boys" >Юноши</option>
         </select>
 
-        <select value={scope} disabled={activeTab==="individual"}
+        <select value={scope}
                 onChange={e=>setScope(e.target.value)}
                 className="border px-3 py-1 rounded">
           <option value="region">Область</option>


### PR DESCRIPTION
## Summary
- filter competitions by region/city/all
- allow changing the scope in the final page
- support scope filtering in API endpoints

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c0f89818832d9b36e327f5dd92a6